### PR TITLE
ChartBar컴포넌트를 Chart에 가져오기

### DIFF
--- a/src/components/Chart/Chart.js
+++ b/src/components/Chart/Chart.js
@@ -4,7 +4,18 @@ import ChartBar from "./ChartBar";
 import "./Chart.css";
 
 const Chart = (props) => {
-  return <div className="chart"></div>;
+  return (
+    <div className="chart">
+      {props.dataPoints.map((dataPoint) => (
+        <ChartBar
+          key={dataPoint.label} //label마다 고유의 값을 가지게 된다.
+          value={dataPoint.value}
+          maxValue={null}
+          label={dataPoint.label}
+        />
+      ))}
+    </div>
+  );
 };
 
 export default Chart;


### PR DESCRIPTION
: 구현 목표
About React.JS
- Section 5 - 76. Chart

:: 구현 사항 설명
- ChartBar 컴포넌트를 Chart.js에 가져와서 사용
- props로 전달
- map메소드 사용으로 같은내용 반복 
- key{dataPoint.label} 을 사용함으로서 label마다 고유의 값을 가지게 된다. 

:: 성장 포인트
- props사용
- map메소드 사용할 때 key 중요! 

::기타